### PR TITLE
[React] Close tag on the last property

### DIFF
--- a/React/README.md
+++ b/React/README.md
@@ -433,19 +433,19 @@ Forked from the excellent [Airbnb React Style Guide](https://github.com/react), 
     <Foo className="stuff" />
     ```
 
-  - If your component has multi-line properties, close its tag on a new line. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
+  - If your component has multi-line properties, close its tag on the last property. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
 
     ```jsx
     // bad
     <Foo
       bar="bar"
-      baz="baz" />
+      baz="baz"
+    />
 
     // good
     <Foo
       bar="bar"
-      baz="baz"
-    />
+      baz="baz" />
     ```
 
 ## Methods


### PR DESCRIPTION
Hey folks. I want to suggest this change for two reasons:

1. That convention is not awesome.
2. Some people want to watch the world burn.

Ok... jokes aside, here are the reasons:

1. Having the close tag on the last property it automatically communicates that is that last one, the end of the whole tag (awesome for reading code).
2. I saw more frequently tags being closed right next to the last property than a line below so I guess it will be friendlier for everyone.