### PR TITLE
JS ES6: Added exception for bare objects

### DIFF
--- a/Javascript(ES6)/README.md
+++ b/Javascript(ES6)/README.md
@@ -146,6 +146,23 @@ Forked from the excellent [Airbnb JavaScript Style Guide](https://github.com/air
     const item = {};
     ```
 
+    **Note:** Exceptions are allowed for when _bare objects_ are required. You can see a valid use case in [True Hashmaps in JavaScript](http://ryanmorr.com/true-hash-maps-in-javascript/). In a case like that, prefer the object creation without a prototype instead of removing the prototype from the object.
+    
+   Note that the recommended usage is not technically a violation of the code style rule, but we include it anyway since it will feel to the developer as a step backwards in the simple object creation direction.
+
+   ```javascript
+   // awful -- non standard
+   const myHashMap = {};
+   myHashMap.__proto__ = null;
+   
+   // bad
+   const myHashMap = {};
+   Object.setPrototype(myHashMap, null);
+   
+   // good
+   const myHashMap = Object.create(null);
+   ```
+
   <a name="es6-computed-properties"></a><a name="3.4"></a>
   - [3.2](#es6-computed-properties) Use computed property names when creating objects with dynamic property names.
 

--- a/Javascript(ES6)/README.md
+++ b/Javascript(ES6)/README.md
@@ -285,7 +285,7 @@ Forked from the excellent [Airbnb JavaScript Style Guide](https://github.com/air
   <a name="objects--prototype-builtins"></a>
   - [3.7](#objects--prototype-builtins) Do not call `Object.prototype` methods directly, such as `hasOwnProperty`, `propertyIsEnumerable`, and `isPrototypeOf`.
 
-    > Why? These methods may be shadowed by properties on the object in question - consider `{ hasOwnProperty: false }` - or, the object may be a null object (`Object.create(null)`).
+    > Why? These methods may be shadowed by properties on the object in question - consider `{ hasOwnProperty: false }` - or, the object may be a bare object (`Object.create(null)`).
 
     ```javascript
     // bad


### PR DESCRIPTION
I think there's a valid use case for using `Object.create()` instead of the literal `{}`. While it's not technically a violation of the standard, I thought including it would be a good idea.