### PR TITLE
Added Contributing guidelines and approvers for each guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to this repository
+
+Thank you for being interested in contributing to this repository! Whether you're a part of Making Sense or not, you rule for helping us build quality guidelines.
+
+Here are a few guidelines for the contributions:
+
+- **Prefer pull requests over issues:** If you have a proposal and it's not too much work, feel free to open a pull request. It's always easier to discuss over a set of changes than on the idea of those changes. Sometimes that is not quite feasible and that's ok too -- but if you have something to show, it's always better to show the real stuff.
+- **Make sure you get the approval from the right people:** If you don't have a general consensus, or if nobody has looked at your changes, contact the following people that will help with the right technologies. Tag them in the PRs / issues so that you can get an answer whenever possible.
+    - JavaScript ES5: [@AlphaGit][user_alphagit], [@MRavinale][user_mravinale], [@NoeliaSFranco][user_noeliasfranco]
+    - JavaScript ES6: [@AlphaGit][user_alphagit], [@MRavinale][user_mravinale], [@NoeliaSFranco][user_noeliasfranco]
+    - Angular 1.x: [@AlphaGit][user_alphagit], [@MRavinale][user_mravinale], [@NoeliaSFranco][user_noeliasfranco]
+    - NodeJs: [@AlphaGit][user_alphagit], [@MRavinale][user_mravinale], [@NoeliaSFranco][user_noeliasfranco]
+    - React: [@JuampiCK][user_juampick], [@KiliSoria][user_kilisoria], [@NoeliaSFranco][user_noeliasfranco]
+    - .NET: [@AlphaGit][user_alphagit], [@MRavinale][user_mravinale], [@MVazquez-MS][user_mvazquez]
+- **If you have merging privileges, make sure the right people has approved the changes:** See previous item for the right people to approve changes for each technology. You should get at least an approval from one of them.
+
+[user_mravinale]: https://github.com/mravinale
+[user_alphagit]: https://github.com/AlphaGit
+[user_juampick]: https://github.com/juampick
+[user_noeliasfranco]: https://github.com/noeliasfranco
+[user_mvazquez]: https://github.com/mvazquez-ms
+[user_kilisoria]: https://github.com/kilisoria


### PR DESCRIPTION
Here's a proposal on contributing guidelines, drafted after a discussion with @mravinale. 

Here's the gist of it, and if it's not obvious from the file, let me know and I can improve it.

There are three problems that we want to avoid, and hopefully this helps:

1. **For external contributors, we don't want items to end up lingering forever.** If an external reviewer sends a change / issue and nobody has time to see it, at least this will give them the change to ping someone personally, and this also means that the people mentioned here are responsible for not letting this repository grow stale.
2. **For internal contributors, we may need an immediate response.** Since sometimes in Making Sense people will work on this in-between assignations, we want a quick response to them. This information will tell them who to pursue to get a timely review. (Same logic as before.)
3. **For conflicting views, we may need someone to have authority and make decisions.** The people indicated here will have the chance to approve / reject changes, since we consider them SME in each of these technologies.

Note that the list of people just started with the SMEs that we currently consider for these technologies, but this is meant to evolve over time in the way that we see best fit. Feel free to suggest new people or to suggest people to be removed from here, being that we can still solve the problems mentioned above.

And if we ever change our mind in the future, feel free to send changes in a new PR! =D

cc @kilisoria (I couldn't add you as a reviewer)