### PR TITLE
Rearrange "propTypes" and "defaultProps" location & initialization

### DIFF
--- a/React/README.md
+++ b/React/README.md
@@ -561,17 +561,7 @@ Forked from the excellent [Airbnb React Style Guide](https://github.com/react), 
 
     ```jsx
     import React, { PropTypes } from 'react';
-
-    const propTypes = {
-      id: PropTypes.number.isRequired,
-      url: PropTypes.string.isRequired,
-      text: PropTypes.string,
-    };
-
-    const defaultProps = {
-      text: 'Hello World',
-    };
-
+    
     class Link extends React.Component {
       static methodsAreOk() {
         return true;
@@ -582,8 +572,15 @@ Forked from the excellent [Airbnb React Style Guide](https://github.com/react), 
       }
     }
 
-    Link.propTypes = propTypes;
-    Link.defaultProps = defaultProps;
+    Link.propTypes = {
+      id: PropTypes.number.isRequired,
+      url: PropTypes.string.isRequired,
+      text: PropTypes.string
+    };
+
+    Link.defaultProps = {
+      text: 'Hello World'
+    };
 
     export default Link;
     ```


### PR DESCRIPTION
Hey folks. This time the suggestion change arised [from other PR](https://github.com/MakingSense/mern-seed/pull/10#discussion_r104018500).

Why? Not 100% sure but I see more often declared in this way & place. I also believe is the way our React fellows in the company like so makes sense!

If we see any disadvantage in the near future we can change it back. For now I'm good with this one.