### PR TITLE
reference to SA1503 incorrect

### DIFF
--- a/CSharp/README.md
+++ b/CSharp/README.md
@@ -194,20 +194,20 @@ public void SomeMethod()
 }
 ```
 
-### Don't use braces for just one line
+### Always use braces even for just one line
 
 [SA1503](http://stylecop.soyuz5.com/SA1503.html)
 
 ```csharp
 // Bad
 if (payment == null)
-{
     return "A payment is required.";
-}
 
 // Good
 if (payment == null)
+{
     return "A payment is required.";
+}
 ```
 
 ## Spacing


### PR DESCRIPTION
A function without curly braces is wrong and is also reflected in the sylecop you referenced