### PR TITLE
Fix "local calls with this" ruleset

### DIFF
--- a/CSharp/CSharpStyleguide.ruleset
+++ b/CSharp/CSharpStyleguide.ruleset
@@ -9,7 +9,7 @@
     <Rule Id="SA1011" Action="Error" /> <!-- Closing square brackets must be spaced correctly -->
     <Rule Id="SA1012" Action="Error" /> <!-- Opening curly brackets must be spaced correctly -->
     <Rule Id="SA1013" Action="Error" /> <!-- Closing curly brackets must be spaced correctly -->
-    <Rule Id="SA1101" Action="Warning" /> <!-- Prefix local calls with this -->
+    <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
     <Rule Id="SA1121" Action="Error" /> <!-- Use built in type alias -->
     <Rule Id="SA1201" Action="Warning" /> <!-- Elements must appear in the correct order -->
     <Rule Id="SA1202" Action="Warning" /> <!-- Elements must be ordered by access -->


### PR DESCRIPTION
@rperez-making discovered that the ruleset for this style is actually wrong and doesn't match with the description. This particular rule behaves the opposite way I thought when I was doing it: a violation means you're not using `this`.

Since we don't really want to enforce using `this` I'm changing the _warning_ for `none`.

Thank you @rperez-making!